### PR TITLE
Add 4.5ms clickfade to end of sample

### DIFF
--- a/plugins/Ninjas2/Ninjas2Plugin.cpp
+++ b/plugins/Ninjas2/Ninjas2Plugin.cpp
@@ -1002,8 +1002,6 @@ void NinjasPlugin::run ( const float**, float** outputs, uint32_t frames,       
                          }
                          // Clickfade: make sure that the end of the sample sounds nice.
                          case CLICKFADE: {
-                              printf("pos: %i, sliceEnd: %i, samplechannels: %i\n",
-                                     pos, sliceEnd, sampleChannels);
                               if (voices[i].adsr.adsr_gain > 0.0f) {
                                    voices[i].adsr.adsr_gain += - float(sampleChannels) / clickfadeSamples;
                               } else {
@@ -1011,7 +1009,6 @@ void NinjasPlugin::run ( const float**, float** outputs, uint32_t frames,       
                                    voices[i].adsr.adsr_gain = 0.0f;
                                    voices[i].active = false;
                               }
-                              printf("adsr_gain: %f\n" , voices[i].adsr.adsr_gain);
                               break;
                          }
                          }

--- a/plugins/Ninjas2/Ninjas2Plugin.hpp
+++ b/plugins/Ninjas2/Ninjas2Plugin.hpp
@@ -144,7 +144,8 @@ private:
     ATTACK,
     DECAY,
     SUSTAIN,
-    RELEASE
+    RELEASE,
+    CLICKFADE
   };
 
   enum slicePlayMode


### PR DESCRIPTION
This adds a 200 sample clickfade section to the end of each slice. Please check the logic before merging.

Fixes #36 