### PR TITLE
Fix submodule include in Makefile

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -6,23 +6,14 @@
 # Modified by Clearly Broken Software
 #
 
-include dpf/Makefile.base.mk
+include $(wildcard dpf/Makefile.base.mk)
 
 all: libs plugins gen
 
-define MISSING_SUBMODULES_ERROR
-
-Cannot find DGL! Please run "make submodules" to clone the missing submodules, then retry building the plugin.
-
-endef
-
 # --------------------------------------------------------------
-submodules: 
-	git submodule update --init --recursive
-
 libs:
 ifeq (,$(wildcard dpf/dgl))
-	$(error $(MISSING_SUBMODULES_ERROR))
+	git submodule update --init --recursive
 endif
 
 ifneq ($(USE_SYSTEM_AUBIO),true)
@@ -74,4 +65,3 @@ endif
 # --------------------------------------------------------------
 
 .PHONY: plugins
-


### PR DESCRIPTION
Every path Make finds in an include has to be available at start of
evaluation. Non-existent include paths will make Make break.
Workaround is to use a wildcard instead of an absolute path.
Instead of printing an error message, just try to fix the underlying
issue.
Fixes  #118