### PR TITLE
Remove aubio_cleanup call in NinjasPlugin::getOnsets

### DIFF
--- a/plugins/Ninjas2/Ninjas2Plugin.cpp
+++ b/plugins/Ninjas2/Ninjas2Plugin.cpp
@@ -1123,7 +1123,6 @@ void NinjasPlugin::getOnsets ()
     }
     
     del_aubio_onset ( onset );
-    aubio_cleanup();
 }
 
 void NinjasPlugin::createSlicesOnsets ()


### PR DESCRIPTION
A call to ``aubio_cleanup`` [clears out important FFTW planner data and gets FFTW in its pristine state when the program was started](https://fftw.org/fftw3_doc/Using-Plans.html) (Also can refer to https://aubio.org/doc/latest/musicutils_8h.html#a2b5d813f8d70b69add6f4811a68c9424). This is problematic in a plugin because a DAW may use this FFTW data, which would abruptly get deleted by this call.

In this case, LMMS extensively uses FFTW and FFTW plans, and it does not know anything about this function being called, which affects every FFTW plan currently used in the application. It should be up to LMMS to cleanup the FFTW cache or not.